### PR TITLE
Check for new git.ref before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,18 @@ A collection of public resources used by RightScale CI
 
 A script designed to be retrieved and executed from CI builds to manage the building and pushing of your containers.
 
-This is work in progress
+Needs the following environment variables:
+
+- `DOCKERHUB_USER`: DockerHub username
+- `DOCKERHUB_PASSWORD`: DockerHub password
+
+Provides the following functions:
+
+- `clean`: Remove intermediate build artifacts
+- `login`: logs into DockerHub
+- `build`: builds Docker image
+- `push`: Pushes Docker image
+- `ci(branch, is_pull_request)`: Depending on the branch name, the pull request status and other conditions that get retrieved at execution time, this function ends executing the `login`, `build` and `push` functions
 
 ## Maintained by
  - [Christian Teijon](https://github.com/crunis)


### PR DESCRIPTION
For new commits to staging branch, only build and push the Docker image if the commit's SHA is not equal to the Docker image git.ref .

Then it is needed to docker pull the image first and docker inspect it
