### PR TITLE
Fix pull request check

### DIFF
--- a/docker-shared.sh
+++ b/docker-shared.sh
@@ -71,7 +71,7 @@ push ()
 #   - build and push an image
 ci ()
 {
-  if [[ "$2" == "true" ]]
+  if [[ "$2" != "false" ]]
   then
     echo "Skipping Docker image build due to pull-request status ($2)"
   elif [[ ! "$1" =~ (^(latest|staging|production-|experimental))|(_cow$) ]]


### PR DESCRIPTION
TRAVIS_PULL_REQUEST is either "false" or the number of the pull request.

This fixes the condition to check if we are in a Pull Request
