### PR TITLE
TL-711 Better error handling

### DIFF
--- a/docker-shared.sh
+++ b/docker-shared.sh
@@ -3,6 +3,10 @@
 # by bash scripts. It contains a main() function which you can call from
 # your own script.
 #
+
+# Automatically exit on error
+set -e
+
 # Before sourcing this script, you MUST define the following:
 #    - a function before_build()
 
@@ -86,8 +90,7 @@ ci ()
     else
       echo "Building $1 tag since current git.ref (${image_git_ref}) doesn't match build's commit sha (${TRAVIS_COMMIT})"
       login
-      build $1
-      push $1
+      build $1 && push $1
     fi
   fi
 }


### PR DESCRIPTION
Adds "set -e" to immediately exit on error. I've gone through the script and tested and didn't find any error condition that we want to ignore.

Adds "build && push " to avoid pushing if the build fails. It's not strictly necessary since we added "set -e" but it is more robust and covers the case if in the future we decide to remove the "set -e" instruction