### PR TITLE
TL-910 keep app_name, org_name or gitref if set

### DIFF
--- a/docker-shared.sh
+++ b/docker-shared.sh
@@ -17,10 +17,10 @@ then
   exit 20
 fi
 
-# Deduce some information about the Docker repository and build args
-org_name=rightscale
-app_name=`basename $PWD`
-gitref=`git rev-parse --verify HEAD`
+# If not provided, deduce some information about the Docker repository and build args
+[ -n "$org_name" ] || org_name=rightscale
+[ -n "$app_name" ] || app_name=`basename $PWD`
+[ -n "$gitref" ]   || gitref=`git rev-parse --verify HEAD`
 
 if [ $? != 0 ]
 then


### PR DESCRIPTION
This allows to set the contents of these variables outside this script.
This will be useful for repositories that build more than one different docker image or the docker image doesn't match the directory name