### PR TITLE
Use TRAVIS_BRANCH to guess current branch

### DIFF
--- a/docker-shared.sh
+++ b/docker-shared.sh
@@ -129,6 +129,10 @@ main ()
   then
     git_branch=$2
     echo "Assuming Git branch '$git_branch' by explicit request"
+  elif [ -n "$TRAVIS_BRANCH" ]
+  then
+    git_branch=$TRAVIS_BRANCH
+    echo "Assuming Git branch '$git_branch' from TRAVIS_BRANCH"
   else
     git_ref=$(git symbolic-ref HEAD 2>/dev/null)
     git_branch=${git_ref##refs/heads/}


### PR DESCRIPTION
When executing "docker login" in a Travis build, $2 doesn't contain the branch and using `git symbolic-ref HEAD`  doesn't work because Travis sets up the repo in "detached" mode.
 
This fixes the problem in Travis while keeping the git trick for local executions.