### PR TITLE
TL-1013 travis-setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # ci
 A collection of public resources used by RightScale CI
 
+## travis-setup.sh
+
+A script designed to help setting up the build environment.
+
+Download and call it at the beginning of the "before_install" section of your build:
+
+```
+before_install:
+  - curl -s https://raw.githubusercontent.com/rightscale/ci/TL-1013_travis-setup/travis-setup.sh | DOCKER=true bash
+```
+
+Pass options/commands via environment variables, these are the available options:
+
+- `DOCKER`: if set to **true**, it will install the specified docker version in APT_DOCKER_PKG (if APT_DOCKER_PKG is unset, it will install the script's default)
+
+
 ## docker-shared.sh
 
 A script designed to be retrieved and executed from CI builds to manage the building and pushing of your containers.

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -1,0 +1,38 @@
+# Automatically exit on error
+set -e
+
+# VARIABLES
+DEFAULT_APT_DOCKER_PKG="docker-engine=1.12.5-0~ubuntu-trusty"
+
+docker_install()
+{
+  if  [ -z "$APT_DOCKER_PKG" ]
+  then
+    echo "*** APT_DOCKER_PKG undefined, using default: $DEFAULT_APT_DOCKER_PKG"
+    export APT_DOCKER_PKG=$DEFAULT_APT_DOCKER_PKG
+  fi
+
+  echo "*** Adding dockerproject key"
+  sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys F76221572C52609D
+  echo "*** Adding apt.dockerproject.org repository (trusty)"
+  echo 'deb "https://apt.dockerproject.org/repo" ubuntu-trusty main' | sudo tee /etc/apt/sources.list.d/docker.list
+  sudo apt-get update
+  echo "*** Installing $APT_DOCKER_PKG"
+  sudo apt-get -y --allow-downgrades -o Dpkg::Options::="--force-confnew" install $APT_DOCKER_PKG && docker -v
+}
+
+check_sudo()
+{
+  if [[ $TRAVIS_SUDO != "true" ]]
+  then
+    echo "!!! ERROR: you need a sudo-enabled (sudo: required) Travis build to use the specified options in travis-setup.sh script (probably you are requesting Docker)"
+    exit 10
+  fi
+}
+
+
+if [[ $DOCKER =~ ^(true|TRUE|1)$ ]]
+then
+  check_sudo
+  docker_install
+fi


### PR DESCRIPTION
The travis-setup.sh is designed to be called from ALL builds at before-install stage. This allows to quickly fix changes on Travis build environment for all builds in one single place.

Right now, it is in charge of setting up a healthy Docker environment, with custom version (allowing pre CE/EE versions)