### PR TITLE
TL-1074 Fix set -e bug

### DIFF
--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -1,11 +1,10 @@
-# Automatically exit on error
-set -e
-
 # VARIABLES
 DEFAULT_APT_DOCKER_PKG="docker-engine=1.12.5-0~ubuntu-trusty"
 
 docker_install()
 {
+  set -e # Automatically exit on error
+
   if  [ -z "$APT_DOCKER_PKG" ]
   then
     echo "*** APT_DOCKER_PKG undefined, using default: $DEFAULT_APT_DOCKER_PKG"


### PR DESCRIPTION
When source-ing the file, the "set -e" was being set for the whole session